### PR TITLE
ci: fetch full history during release_helm_chart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Helm
         uses: azure/setup-helm@v3


### PR DESCRIPTION
Set fetch-depth to 0 for repository checkout so the workflow can find the gh-pages branch.