### PR TITLE
Fixed using datasource variable for dashboards variables

### DIFF
--- a/dashboards/pfsense_carp.json
+++ b/dashboards/pfsense_carp.json
@@ -306,6 +306,7 @@
       {
         "allValue": "",
         "current": {},
+        "datasource": { "type": "prometheus", "uid": "$datasource" },
         "definition": "label_values(pfsense_carp_enabled,host)",
         "description": "Selects the pfSense host to visualize.",
         "includeAll": true,

--- a/dashboards/pfsense_firewall.json
+++ b/dashboards/pfsense_firewall.json
@@ -298,6 +298,7 @@
       {
         "allValue": "",
         "current": {},
+        "datasource": { "type": "prometheus", "uid": "$datasource" },
         "definition": "label_values(pfsense_firewall_states_usage_ratio,host)",
         "description": "Selects the pfSense host to visualize.",
         "includeAll": true,

--- a/dashboards/pfsense_gateways.json
+++ b/dashboards/pfsense_gateways.json
@@ -609,6 +609,7 @@
       {
         "allValue": "",
         "current": {},
+        "datasource": { "type": "prometheus", "uid": "$datasource" },
         "definition": "label_values(pfsense_gateway_up,host)",
         "description": "The pfSense host whose data should be visualized.",
         "includeAll": true,
@@ -628,6 +629,7 @@
       },
       {
         "current": {},
+        "datasource": { "type": "prometheus", "uid": "$datasource" },
         "definition": "label_values(pfsense_gateway_up,name)",
         "description": "Selects the gateway to visualize.",
         "includeAll": true,

--- a/dashboards/pfsense_interface.json
+++ b/dashboards/pfsense_interface.json
@@ -817,6 +817,7 @@
       },
       {
         "current": {},
+        "datasource": { "type": "prometheus", "uid": "$datasource" },
         "definition": "label_values(pfsense_interface_up,host)",
         "description": "Selects the pfSense host to visualize.",
         "includeAll": true,
@@ -835,6 +836,7 @@
       },
       {
         "current": {},
+        "datasource": { "type": "prometheus", "uid": "$datasource" },
         "definition": "label_values(pfsense_interface_up,descr)",
         "description": "Selects the interface to visualize.",
         "includeAll": true,

--- a/dashboards/pfsense_services.json
+++ b/dashboards/pfsense_services.json
@@ -236,6 +236,7 @@
       },
       {
         "current": {},
+        "datasource": { "type": "prometheus", "uid": "$datasource" },
         "definition": "label_values(pfsense_service_up,host)",
         "description": "Selects the pfSense host to visualize.",
         "includeAll": true,
@@ -254,6 +255,7 @@
       },
       {
         "current": {},
+        "datasource": { "type": "prometheus", "uid": "$datasource" },
         "definition": "label_values(pfsense_service_up,name)",
         "description": "Selects the service to visualize.",
         "includeAll": true,

--- a/dashboards/pfsense_system.json
+++ b/dashboards/pfsense_system.json
@@ -1065,6 +1065,7 @@
       {
         "allValue": "",
         "current": {},
+        "datasource": { "type": "prometheus", "uid": "$datasource" },
         "definition": "label_values(pfsense_system_memory_usage_ratio,host)",
         "description": "Selects the pfSense host to visualize.",
         "includeAll": true,


### PR DESCRIPTION
The $datasource template variable was only referenced by some of the sub-variables ($job, $instance), while others ($host, $gateway, $interface, $name) were missing the datasource field entirely, causing them to fall back to Grafana's default datasource instead of the user-selected one.
This worked as long as the default datasource happened to be the correct Prometheus instance, but broke when it wasn't.
Added the missing datasource references to all affected variables across all 6 dashboards.

Thanks for a great project! :)
